### PR TITLE
Sonar API Param Refactor

### DIFF
--- a/ui/components/RepoHealth.tsx
+++ b/ui/components/RepoHealth.tsx
@@ -130,7 +130,7 @@ const RepoHealth: React.FC<RepoHealthProps> = ({
       tests(repo, queryPeriodDays, repoTabStats.data?.tests[0]?.totalTests),
       codeQuality(
         repo.codeQuality,
-        repo.name,
+        repo.id,
         repo.defaultBranch,
         repoTabStats.data
           ? combinedQualityGate(

--- a/ui/components/repo-tabs/codeQuality.tsx
+++ b/ui/components/repo-tabs/codeQuality.tsx
@@ -1197,7 +1197,7 @@ const tabLabel = (codeQuality: RepoAnalysis['codeQuality']) => {
 
 export default (
   codeQuality: RepoAnalysis['codeQuality'],
-  repositoryName: string,
+  repositoryId: string,
   defaultBranch: string | undefined,
   sonarQualityGate: string | null
 ): Tab => ({
@@ -1210,7 +1210,7 @@ export default (
       {
         collectionName,
         project,
-        repositoryName,
+        repositoryId,
         defaultBranch,
       },
       { enabled: showNewSonar === true }


### PR DESCRIPTION
- Refactored the sonar APIs to use repository ID rather than repository name as a parameter. 