### PR TITLE
Tabs V2 Migration

### DIFF
--- a/ui/components/repo-tabs/branches/index.tsx
+++ b/ui/components/repo-tabs/branches/index.tsx
@@ -256,7 +256,7 @@ export default (
 ): Tab => {
   return {
     title: 'Branches',
-    count: branchesCount ?? branches.total,
+    count: branchesCount ?? 0,
     Component: () => {
       return (
         <Branches

--- a/ui/components/repo-tabs/builds.tsx
+++ b/ui/components/repo-tabs/builds.tsx
@@ -1,7 +1,6 @@
 import React, { Fragment, useCallback, useState } from 'react';
 import ReactTooltip from 'react-tooltip';
 import prettyMilliseconds from 'pretty-ms';
-import type { RepoAnalysis } from '../../../shared/types.js';
 import { num, shortDate } from '../../helpers/utils.js';
 import AlertMessage from '../common/AlertMessage.js';
 import type { Tab } from './Tabs.js';
@@ -334,14 +333,13 @@ const Builds: React.FC<{
 };
 
 export default (
-  builds: RepoAnalysis['builds'],
   repositoryId: string,
   repositoryName: string,
   buildsCount?: number
 ): Tab => {
   return {
     title: 'Builds',
-    count: buildsCount ?? (builds?.count || 0),
+    count: buildsCount ?? 0,
     Component: () => {
       return <Builds repositoryId={repositoryId} repositoryName={repositoryName} />;
     },

--- a/ui/components/repo-tabs/codeQuality.tsx
+++ b/ui/components/repo-tabs/codeQuality.tsx
@@ -5,8 +5,6 @@ import { formatDebt, num, shortDate } from '../../helpers/utils.js';
 import AlertMessage from '../common/AlertMessage.js';
 import type { Tab } from './Tabs.js';
 import TabContents from './TabContents.js';
-import { combinedQualityGateStatus } from '../code-quality-utils.js';
-
 import { trpc } from '../../helpers/trpc.js';
 import { useCollectionAndProject } from '../../hooks/query-hooks.js';
 import Loading from '../Loading.jsx';
@@ -734,18 +732,6 @@ const AnalysisTable: React.FC<{ codeQuality: NonNullable<UICodeQuality2> }> = ({
     </table>
   );
 };
-
-const tabLabel = (codeQuality: RepoAnalysis['codeQuality']) => {
-  const state = combinedQualityGateStatus(codeQuality);
-  if (state !== 'fail') return state;
-  if (codeQuality?.length === 1) return state;
-
-  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-  const warnCount = codeQuality!.filter(q => q.quality.gate === 'fail').length;
-  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-  return `${Math.round((warnCount * 100) / codeQuality!.length)}% fail`;
-};
-
 export default (
   codeQuality: RepoAnalysis['codeQuality'],
   repositoryId: string,
@@ -753,7 +739,7 @@ export default (
   sonarQualityGate: string | null
 ): Tab => ({
   title: 'Code quality',
-  count: sonarQualityGate || tabLabel(codeQuality),
+  count: sonarQualityGate || 'unknown',
   Component: () => {
     const { collectionName, project } = useCollectionAndProject();
     const sonarMeasures = trpc.sonar.getRepoSonarMeasures.useQuery({

--- a/ui/components/repo-tabs/commits.tsx
+++ b/ui/components/repo-tabs/commits.tsx
@@ -131,11 +131,11 @@ export default (
   queryPeriodDays: number,
   commitsCount?: number
 ): Tab => {
-  const { commits, id } = repo;
+  const { id } = repo;
 
   return {
     title: 'Commits',
-    count: commitsCount ?? commits.count,
+    count: commitsCount ?? 0,
     Component: () => {
       return <CommitsTable repositoryId={id} queryPeriodDays={queryPeriodDays} />;
     },

--- a/ui/components/repo-tabs/prs.tsx
+++ b/ui/components/repo-tabs/prs.tsx
@@ -15,7 +15,7 @@ export default (
   totalPullRequests?: number
 ): Tab => ({
   title: 'Pull requests',
-  count: totalPullRequests ?? prs.total,
+  count: totalPullRequests ?? 0,
   Component: () => {
     const [showNewPrs] = useQueryParam('pr-v2', asBoolean);
     const pullRequest = trpc.pullRequests.getPullRequestsSummaryForRepo.useQuery(

--- a/ui/components/repo-tabs/tests.tsx
+++ b/ui/components/repo-tabs/tests.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import type { RepoAnalysis } from '../../../shared/types.js';
 import type { Tab } from './Tabs.js';
-import { numberOfTests } from '../../../shared/repo-utils.js';
 import BuildPipelineTests from './BuildPipelineTests.jsx';
 
 export default (
@@ -10,7 +9,7 @@ export default (
   totalTests?: number
 ): Tab => ({
   title: 'Tests',
-  count: totalTests ?? numberOfTests(repo),
+  count: totalTests ?? 0,
   Component: () => (
     <BuildPipelineTests repositoryId={repo.id} queryPeriodDays={queryPeriodDays} />
   ),


### PR DESCRIPTION
- Migrated from using JSON APIs to showing the Repository tabs head statistic to using DB APIs. This will ensure the inner tab content and tab heads are consistent. 
- Removed unused logical APIs.