### PR TITLE
Partially Succeeded Builds Considered For Tests and Coverage

### DIFF
--- a/backend/models/testruns.ts
+++ b/backend/models/testruns.ts
@@ -304,6 +304,12 @@ export const getTestsAndCoveragePipelinesForDownload = async ({
     repositoryName: x.repositoryName,
     repositoryUrl: x.repositoryUrl,
     totalTests: x.latestTest?.hasTests ? x.latestTest.totalTests : 0,
+    totalBranches: x.latestCoverage?.hasCoverage
+      ? x.latestCoverage.coverage.totalBranches
+      : 0,
+    coveredBranches: x.latestCoverage?.hasCoverage
+      ? x.latestCoverage.coverage.coveredBranches
+      : 0,
     totalCoverage: x.latestCoverage?.hasCoverage
       ? divide(
           x.latestCoverage.coverage.coveredBranches,

--- a/backend/models/tests-coverages.ts
+++ b/backend/models/tests-coverages.ts
@@ -82,7 +82,12 @@ export const getMainBranchBuildIds = (
                 $and: [
                   { $eq: ['$repository.id', '$$repositoryId'] },
                   { $eq: ['$sourceBranch', '$$defaultBranch'] },
-                  { $eq: ['$result', 'succeeded'] },
+                  {
+                    $or: [
+                      { $eq: ['$result', 'succeeded'] },
+                      { $eq: ['$result', 'partiallySucceeded'] },
+                    ],
+                  },
                 ],
               },
               ...additionalQuery,

--- a/backend/server/repo-api-endpoints.ts
+++ b/backend/server/repo-api-endpoints.ts
@@ -140,6 +140,14 @@ const drawerDownloads = {
           value: x => x.failedTests,
         },
         {
+          title: 'Branches covered',
+          value: x => x.coveredBranches,
+        },
+        {
+          title: 'Total branches',
+          value: x => x.totalBranches,
+        },
+        {
           title: 'Coverage %',
           value: x => Number(x.totalCoverage.toFixed(0)),
         },


### PR DESCRIPTION
- Tests and coverage will now also consider partially succeeded builds on the main branch along with the succeeded builds on main branch.
- Tests and Coverage drawer excel sheet will now show total branches and branches covered to give better sense of coverage.